### PR TITLE
Setup Dependabot to use GitHub private registries

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,3 +13,4 @@ updates:
   pull-request-branch-name:
     separator: "-"
   registries: "*"
+  open-pull-requests-limit: 0


### PR DESCRIPTION
https://trello.com/c/sAbjY4Wa/91-deploy-distribute-updated-dependabot-configuration